### PR TITLE
fix: end the Live Activity when the app is terminated

### DIFF
--- a/OneEighty/LiveActivityManager.swift
+++ b/OneEighty/LiveActivityManager.swift
@@ -64,15 +64,24 @@ final class LiveActivityManager {
     /// `pushIfClaimed`), so a coalesced/newer push claims the newer version and
     /// a superseded pending push is dropped when its (older) version is rejected.
     func apply(_ state: AppState) {
-        // No local activity handle: before assuming none exists anywhere and
-        // racing to create one, check whether the system already has one —
-        // e.g. this is the widget extension process, whose own LiveActivityManager
-        // instance never called startActivity() itself but shares the same
-        // cross-process store as the process that did. Blindly starting a new
-        // activity here would tear down and replace the real, on-screen one
-        // via cleanupStaleActivities(), and would burn a version claim without
-        // ever reaching the activity actually visible to the user.
+        // No local activity handle. What we do next depends on whether playback
+        // is on, and this is the invariant that makes "app terminated → Live
+        // Activity closed" reliable across EVERY entry path (cold UI launch, a
+        // background relaunch by an AudioPlaybackIntent, a stop from anywhere):
         if currentActivity == nil {
+            // Stopped with nothing local: any activity still registered with the
+            // system is an orphan from a terminated session (iOS delivers no
+            // reliable callback when a suspended app is killed) or a just-stopped
+            // intent in a fresh process. End it and stay dark — never adopt or
+            // start one for a stopped state. Returning immediately also defeats
+            // the async-end race: we never touch the not-yet-ended orphan again.
+            guard state.isPlaying else {
+                cleanupStaleActivities()
+                return
+            }
+            // Playing with no local handle: reuse the system's activity if one
+            // exists (a fresh process relaunched by an intent) rather than
+            // stacking a second one on top of the real, on-screen activity.
             adoptExistingActivityIfPresent()
         }
 
@@ -179,6 +188,31 @@ final class LiveActivityManager {
         lastSentState = nil
         confirmedState = nil
         tracker.reset()
+    }
+
+    /// Synchronously end every registered Live Activity, blocking the caller up
+    /// to `timeout` for the async end requests to actually dispatch. The app
+    /// termination path (`AppDelegate.applicationWillTerminate`) has ~5s before
+    /// the process is killed; a fire-and-forget `Task` may never run before
+    /// SIGKILL, so we wait here to make "closed while running → Live Activity
+    /// ended" reliable rather than best-effort. Detached tasks run off the main
+    /// actor so blocking the (main-thread) caller cannot deadlock them.
+    func endAllActivitiesBlocking(timeout: TimeInterval) {
+        let activities = Activity<OneEightyActivityAttributes>.activities
+        currentActivity = nil
+        contentUpdateTask?.cancel()
+        contentUpdateTask = nil
+        guard !activities.isEmpty else { return }
+
+        let group = DispatchGroup()
+        for activity in activities {
+            group.enter()
+            Task.detached {
+                await activity.end(nil, dismissalPolicy: .immediate)
+                group.leave()
+            }
+        }
+        _ = group.wait(timeout: .now() + timeout)
     }
 
     func cleanupStaleActivities() {

--- a/OneEighty/OneEightyApp.swift
+++ b/OneEighty/OneEightyApp.swift
@@ -14,15 +14,13 @@ private let logger = Logger(subsystem: "com.danielbutler.OneEighty", category: "
 class AppDelegate: NSObject, UIApplicationDelegate {
     func applicationWillTerminate(_ application: UIApplication) {
         logger.info("applicationWillTerminate — cleaning up")
-        // Best-effort only: iOS does not guarantee this async work completes
-        // before the process dies (and a SIGKILL skips this method entirely).
-        // The real safety net is LiveActivityManager.startActivity() ending
-        // any orphaned activities it finds on the next launch.
-        for activity in Activity<OneEightyActivityAttributes>.activities {
-            Task.detached {
-                await activity.end(nil, dismissalPolicy: .immediate)
-            }
-        }
+        // Block (bounded) so the end requests actually dispatch before the
+        // process dies, instead of firing a Task that may never run. This is
+        // called only when the app is still executing at termination (a SIGKILL
+        // of a suspended app skips it entirely); the safety net for that case is
+        // apply()'s invariant, which ends orphaned activities on the next launch
+        // or store update.
+        LiveActivityManager.shared.endAllActivitiesBlocking(timeout: 3)
         AudioSessionManager.shared.deactivate()
     }
 }

--- a/OneEightyTests/LiveActivityManagerTests.swift
+++ b/OneEightyTests/LiveActivityManagerTests.swift
@@ -176,6 +176,63 @@ final class LiveActivityManagerTests: XCTestCase {
                        "CRITICAL isPlaying transition must bypass throttle and push immediately")
     }
 
+    // MARK: - "app terminated → Live Activity closed"
+
+    /// iOS delivers no reliable callback when a suspended app is killed, so a
+    /// Live Activity from a terminated session stays registered with the system.
+    /// When a fresh process (cold launch, or a background relaunch by an intent)
+    /// applies a STOPPED state with no local activity handle, it must END that
+    /// orphan rather than adopting/refreshing it — leaving no stale Dynamic
+    /// Island on screen.
+    func testStoppedApplyWithNoLocalHandleEndsOrphanInsteadOfAdoptingIt() async throws {
+        // A previous session started an activity and was terminated without
+        // ending it — the system still has it registered.
+        let previous = LiveActivityManager.makeForTesting(store: InMemoryPlaybackStore())
+        previous.startActivity(bpm: 190, isPlaying: true)
+        try await Task.sleep(nanoseconds: 300_000_000)
+        XCTAssertEqual(Activity<OneEightyActivityAttributes>.activities.count, 1,
+                       "precondition: orphaned activity should be registered with the system")
+
+        // Fresh process: a new manager with no local currentActivity applies a
+        // stopped state (cold launch, or a Stop intent that woke the app).
+        let fresh = LiveActivityManager.makeForTesting(store: InMemoryPlaybackStore())
+        fresh.apply(AppState(version: 1, bpm: 180, isPlaying: false))
+        try await Task.sleep(nanoseconds: 300_000_000)
+
+        XCTAssertEqual(Activity<OneEightyActivityAttributes>.activities.count, 0,
+                       "a stopped apply with no local handle must end the orphan, not keep it on screen")
+    }
+
+    /// Ending the orphan on a stopped apply must not permanently block the
+    /// activity: once playback actually begins, it is created.
+    func testStoppedApplyThenPlayStillStartsActivity() async throws {
+        let manager = LiveActivityManager.makeForTesting(store: InMemoryPlaybackStore())
+        manager.apply(AppState(version: 1, bpm: 180, isPlaying: false))   // stays dark
+        try await Task.sleep(nanoseconds: 200_000_000)
+        XCTAssertEqual(Activity<OneEightyActivityAttributes>.activities.count, 0,
+                       "no activity should exist while stopped with no local handle")
+
+        manager.apply(AppState(version: 2, bpm: 180, isPlaying: true))    // user presses play
+        try await Task.sleep(nanoseconds: 300_000_000)
+        XCTAssertEqual(Activity<OneEightyActivityAttributes>.activities.count, 1,
+                       "starting playback must create the activity")
+    }
+
+    /// The termination path must actually end the activity before returning,
+    /// not fire a Task that may never run before the process is killed.
+    func testEndAllActivitiesBlockingEndsBeforeReturning() async throws {
+        let manager = LiveActivityManager.makeForTesting(store: InMemoryPlaybackStore())
+        manager.startActivity(bpm: 180, isPlaying: true)
+        try await Task.sleep(nanoseconds: 300_000_000)
+        XCTAssertEqual(Activity<OneEightyActivityAttributes>.activities.count, 1,
+                       "precondition: an activity is on screen")
+
+        manager.endAllActivitiesBlocking(timeout: 3)
+
+        XCTAssertEqual(Activity<OneEightyActivityAttributes>.activities.count, 0,
+                       "endAllActivitiesBlocking must end the activity before returning")
+    }
+
     func testResetClearsLastSentState() {
         let manager = LiveActivityManager.makeForTesting(store: InMemoryPlaybackStore())
         manager.startActivity(bpm: 180, isPlaying: true)


### PR DESCRIPTION
## Problem

Closing the app left a frozen Dynamic Island / Live Activity on screen. This is partly by design — iOS keeps Live Activities alive after the app's process ends (a delivery/sports app shows status with the app closed) and delivers **no reliable callback** when a suspended app is killed. But two gaps made it worse than necessary:

1. The "clean up orphans on next launch" logic only ran inside `startActivity()`, i.e. **only if the user pressed START**. On a passive relaunch, `apply()` would *adopt* the orphan and refresh it to "stopped", keeping the stale DI alive.
2. `applicationWillTerminate` ended activities with a fire-and-forget `Task`, which may never run before the process is killed.

## Fix

**One invariant in `LiveActivityManager.apply()`:** when there's no local activity handle and playback is **stopped**, end any system-registered orphan and stay dark — never adopt or start one. This holds on *every* entry path:
- cold UI launch (`hydrate()` → `apply()`)
- a background relaunch by a Start/Stop `AudioPlaybackIntent` (never runs the UI launch path — the prior narrow fix missed this)
- a stop from anywhere

Returning immediately also defeats the async-end race (we never touch the not-yet-ended orphan again). Playing states still adopt the existing activity, so relaunch-by-intent-while-playing keeps working.

**Reliable terminate:** `applicationWillTerminate` now calls a bounded (3s) synchronous `endAllActivitiesBlocking()` — detached tasks so the main-thread caller can't deadlock — so the end requests actually dispatch before the process dies.

## Behavior

| Situation | Result |
|---|---|
| Closed while **running** (foreground / audio-active background) | Ended synchronously in `applicationWillTerminate`. |
| **Suspended then killed** (no iOS callback exists) | Ended by `apply()`'s invariant on the next launch **or** intent — earliest possible moment. |
| Stop from lock screen / intent in a fresh process | Orphan ended, no frozen "stopped" DI. |
| **Backgrounded while playing** | Kept — lock-screen control preserved. |

The one thing still physically impossible: closing the DI *at the instant* a suspended app is SIGKILL'd — no code runs then. It's now gone the moment the app next does anything.

## Tests

3 new tests (general orphan-end via `apply()`, stop-then-play still starts, blocking-terminate ends before returning) plus the existing playing-adoption test to guard the relaunch-while-playing path. Full unit suite: 104/104, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0138cg9o6764rfM45N2jUWFq