### PR TITLE
chore: rename bundle-id classifier com.danielbutler → app.rekuro

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 - **OneEightyWatch Watch App/** — watchOS companion
 - **OneEightyWidget/** — WidgetKit live activity
 - BPM range: 150–230 SPM
-- Bundle ID: com.danielbutler.OneEighty
+- Bundle ID: app.rekuro.OneEighty
 
 ## Build & Test
 ```bash
@@ -27,7 +27,7 @@ The iPhone 17 Pro simulator (iOS 26) requires device family 4 in the app's Info.
 APP_PATH=./build/Build/Products/Debug-iphonesimulator/OneEighty.app
 /usr/libexec/PlistBuddy -c "Add UIDeviceFamily: integer 4" "$APP_PATH/Info.plist"
 xcrun simctl install booted "$APP_PATH"
-xcrun simctl launch booted com.danielbutler.OneEighty
+xcrun simctl launch booted app.rekuro.OneEighty
 ```
 
 Note: `xcodebuild test` bypasses this issue (it installs via a different mechanism).

--- a/OneEighty.xcodeproj/project.pbxproj
+++ b/OneEighty.xcodeproj/project.pbxproj
@@ -643,13 +643,13 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = OneEightyWatch;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = com.danielbutler.OneEighty;
+				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = app.rekuro.OneEighty;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.danielbutler.OneEighty.watchkitapp;
+				PRODUCT_BUNDLE_IDENTIFIER = app.rekuro.OneEighty.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
@@ -677,13 +677,13 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = OneEightyWatch;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = com.danielbutler.OneEighty;
+				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = app.rekuro.OneEighty;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.danielbutler.OneEighty.watchkitapp;
+				PRODUCT_BUNDLE_IDENTIFIER = app.rekuro.OneEighty.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
@@ -707,7 +707,7 @@
 				DEVELOPMENT_TEAM = K7T7J4BD4W;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.danielbutler.OneEightyWatch-Watch-AppTests";
+				PRODUCT_BUNDLE_IDENTIFIER = "app.rekuro.OneEightyWatch-Watch-AppTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
@@ -730,7 +730,7 @@
 				DEVELOPMENT_TEAM = K7T7J4BD4W;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.danielbutler.OneEightyWatch-Watch-AppTests";
+				PRODUCT_BUNDLE_IDENTIFIER = "app.rekuro.OneEightyWatch-Watch-AppTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
@@ -752,7 +752,7 @@
 				DEVELOPMENT_TEAM = K7T7J4BD4W;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.danielbutler.OneEightyWatch-Watch-AppUITests";
+				PRODUCT_BUNDLE_IDENTIFIER = "app.rekuro.OneEightyWatch-Watch-AppUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
@@ -774,7 +774,7 @@
 				DEVELOPMENT_TEAM = K7T7J4BD4W;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.danielbutler.OneEightyWatch-Watch-AppUITests";
+				PRODUCT_BUNDLE_IDENTIFIER = "app.rekuro.OneEightyWatch-Watch-AppUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
@@ -931,7 +931,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.danielbutler.OneEighty;
+				PRODUCT_BUNDLE_IDENTIFIER = app.rekuro.OneEighty;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
@@ -965,7 +965,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.danielbutler.OneEighty;
+				PRODUCT_BUNDLE_IDENTIFIER = app.rekuro.OneEighty;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
@@ -987,7 +987,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.danielbutler.OneEightyTests;
+				PRODUCT_BUNDLE_IDENTIFIER = app.rekuro.OneEightyTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
@@ -1009,7 +1009,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.danielbutler.OneEightyTests;
+				PRODUCT_BUNDLE_IDENTIFIER = app.rekuro.OneEightyTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
@@ -1029,7 +1029,7 @@
 				DEVELOPMENT_TEAM = K7T7J4BD4W;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.danielbutler.OneEightyUITests;
+				PRODUCT_BUNDLE_IDENTIFIER = app.rekuro.OneEightyUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
@@ -1049,7 +1049,7 @@
 				DEVELOPMENT_TEAM = K7T7J4BD4W;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.danielbutler.OneEightyUITests;
+				PRODUCT_BUNDLE_IDENTIFIER = app.rekuro.OneEightyUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
@@ -1080,7 +1080,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.danielbutler.OneEighty.Widget;
+				PRODUCT_BUNDLE_IDENTIFIER = app.rekuro.OneEighty.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -1111,7 +1111,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.danielbutler.OneEighty.Widget;
+				PRODUCT_BUNDLE_IDENTIFIER = app.rekuro.OneEighty.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/OneEighty/AVAudioOutput.swift
+++ b/OneEighty/AVAudioOutput.swift
@@ -2,7 +2,7 @@
 import AVFoundation
 import os
 
-private let logger = Logger(subsystem: "com.danielbutler.OneEighty", category: "AudioOutput")
+private let logger = Logger(subsystem: "app.rekuro.OneEighty", category: "AudioOutput")
 
 @MainActor
 final class AVAudioOutput: AudioOutput {

--- a/OneEighty/ActivityUpdateTracker.swift
+++ b/OneEighty/ActivityUpdateTracker.swift
@@ -13,7 +13,7 @@ final class ActivityUpdateTracker {
     private(set) var updateTimestamps: [Date] = []
     /// Monotonic count of all updates recorded (not affected by window pruning).
     private(set) var totalUpdateCount: Int = 0
-    private let logger = Logger(subsystem: "com.danielbutler.OneEighty", category: "UpdateTracker")
+    private let logger = Logger(subsystem: "app.rekuro.OneEighty", category: "UpdateTracker")
 
     init(minimumInterval: TimeInterval = 0.3, budgetWarningThreshold: Int = 40) {
         self.minimumInterval = minimumInterval

--- a/OneEighty/AppGroupPlaybackStore.swift
+++ b/OneEighty/AppGroupPlaybackStore.swift
@@ -3,10 +3,10 @@ import Combine
 import Foundation
 import os
 
-private let logger = Logger(subsystem: "com.danielbutler.OneEighty", category: "PlaybackStore")
+private let logger = Logger(subsystem: "app.rekuro.OneEighty", category: "PlaybackStore")
 
 private enum DarwinName {
-    static let changed = "com.danielbutler.OneEighty.state.changed"
+    static let changed = "app.rekuro.OneEighty.state.changed"
 }
 
 @MainActor
@@ -19,7 +19,7 @@ final class AppGroupPlaybackStore: PlaybackStore {
 
     private nonisolated let fileURL: URL
     private nonisolated let defaults: UserDefaults
-    private nonisolated let ioQueue = DispatchQueue(label: "com.danielbutler.OneEighty.store.io")
+    private nonisolated let ioQueue = DispatchQueue(label: "app.rekuro.OneEighty.store.io")
 
     /// Dedicated synchronization for the Live Activity claim/budget state ONLY.
     /// Deliberately NOT `ioQueue`: the claim methods are called from `@MainActor`
@@ -41,10 +41,10 @@ final class AppGroupPlaybackStore: PlaybackStore {
 
     convenience init() {
         let container = FileManager.default
-            .containerURL(forSecurityApplicationGroupIdentifier: "group.com.danielbutler.OneEighty")
+            .containerURL(forSecurityApplicationGroupIdentifier: "group.app.rekuro.OneEighty")
         let url = (container ?? FileManager.default.temporaryDirectory)
             .appendingPathComponent("state.json")
-        let defaults = UserDefaults(suiteName: "group.com.danielbutler.OneEighty") ?? .standard
+        let defaults = UserDefaults(suiteName: "group.app.rekuro.OneEighty") ?? .standard
         self.init(fileURL: url, defaults: defaults)
     }
 

--- a/OneEighty/ContentView.swift
+++ b/OneEighty/ContentView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 import os
 
-private let logger = Logger(subsystem: "com.danielbutler.OneEighty", category: "ContentView")
+private let logger = Logger(subsystem: "app.rekuro.OneEighty", category: "ContentView")
 
 struct ContentView: View {
     @Environment(\.scenePhase) private var scenePhase

--- a/OneEighty/LiveActivityManager.swift
+++ b/OneEighty/LiveActivityManager.swift
@@ -9,7 +9,7 @@ import ActivityKit
 import Foundation
 import os
 
-private let logger = Logger(subsystem: "com.danielbutler.OneEighty", category: "LiveActivity")
+private let logger = Logger(subsystem: "app.rekuro.OneEighty", category: "LiveActivity")
 
 /// Local content snapshot for pushing a Live Activity update. Distinct from
 /// the transitional `PlaybackState` (OneEightyEngine.swift) — this manager is

--- a/OneEighty/OneEighty.entitlements
+++ b/OneEighty/OneEighty.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.com.danielbutler.OneEighty</string>
+		<string>group.app.rekuro.OneEighty</string>
 	</array>
 </dict>
 </plist>

--- a/OneEighty/OneEightyApp.swift
+++ b/OneEighty/OneEightyApp.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import ActivityKit
 import os
 
-private let logger = Logger(subsystem: "com.danielbutler.OneEighty", category: "AppLifecycle")
+private let logger = Logger(subsystem: "app.rekuro.OneEighty", category: "AppLifecycle")
 
 class AppDelegate: NSObject, UIApplicationDelegate {
     func applicationWillTerminate(_ application: UIApplication) {
@@ -38,14 +38,14 @@ struct OneEightyApp: App {
         // OneEightyEngine() touches AppGroupPlaybackStore.shared, which seeds its
         // in-memory projection from disk (state.json) on first access.
         if ProcessInfo.processInfo.arguments.contains("--reset-state") {
-            if let defaults = UserDefaults(suiteName: "group.com.danielbutler.OneEighty") {
+            if let defaults = UserDefaults(suiteName: "group.app.rekuro.OneEighty") {
                 defaults.removeObject(forKey: "bpm")
                 defaults.removeObject(forKey: "isPlaying")
                 defaults.removeObject(forKey: "volume")
             }
             // Delete the versioned store's backing file so it seeds from defaults.
             if let container = FileManager.default
-                .containerURL(forSecurityApplicationGroupIdentifier: "group.com.danielbutler.OneEighty") {
+                .containerURL(forSecurityApplicationGroupIdentifier: "group.app.rekuro.OneEighty") {
                 try? FileManager.default.removeItem(at: container.appendingPathComponent("state.json"))
             }
         }

--- a/OneEighty/OneEightyEngine.swift
+++ b/OneEighty/OneEightyEngine.swift
@@ -16,7 +16,7 @@ import Observation
 import UIKit
 import os
 
-private let logger = Logger(subsystem: "com.danielbutler.OneEighty", category: "OneEightyEngine")
+private let logger = Logger(subsystem: "app.rekuro.OneEighty", category: "OneEightyEngine")
 
 /// Transitional type — still consumed by PhoneSessionManager and StateSubscriber
 /// (watch-sync reconciliation). LiveActivityManager has fully migrated off it onto

--- a/OneEighty/OneEightyIntents.swift
+++ b/OneEighty/OneEightyIntents.swift
@@ -9,7 +9,7 @@ import AppIntents
 import Foundation
 import os
 
-private let logger = Logger(subsystem: "com.danielbutler.OneEighty", category: "Intents")
+private let logger = Logger(subsystem: "app.rekuro.OneEighty", category: "Intents")
 
 struct ToggleOneEightyIntent: AudioPlaybackIntent {
     static var title: LocalizedStringResource = "Toggle OneEighty"

--- a/OneEighty/PhoneSessionManager.swift
+++ b/OneEighty/PhoneSessionManager.swift
@@ -12,7 +12,7 @@ import UIKit
 import WatchConnectivity
 import os
 
-private let logger = Logger(subsystem: "com.danielbutler.OneEighty", category: "PhoneSession")
+private let logger = Logger(subsystem: "app.rekuro.OneEighty", category: "PhoneSession")
 
 @MainActor
 final class PhoneSessionManager: NSObject, StateSubscriber {

--- a/OneEighty/TickScheduler.swift
+++ b/OneEighty/TickScheduler.swift
@@ -8,7 +8,7 @@
 import AVFoundation
 import os
 
-private let logger = Logger(subsystem: "com.danielbutler.OneEighty", category: "TickScheduler")
+private let logger = Logger(subsystem: "app.rekuro.OneEighty", category: "TickScheduler")
 
 /// Schedules tick buffer playback using AVAudioTime for sample-accurate timing.
 /// The caller owns the AVAudioEngine and AVAudioPlayerNode; this class only

--- a/OneEightyWatch Watch App/WatchSessionManager.swift
+++ b/OneEightyWatch Watch App/WatchSessionManager.swift
@@ -9,7 +9,7 @@
 import WatchConnectivity
 import os
 
-private let logger = Logger(subsystem: "com.danielbutler.OneEighty.watchkitapp", category: "WatchSession")
+private let logger = Logger(subsystem: "app.rekuro.OneEighty.watchkitapp", category: "WatchSession")
 
 @Observable
 @MainActor

--- a/OneEightyWidgetExtension.entitlements
+++ b/OneEightyWidgetExtension.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.com.danielbutler.OneEighty</string>
+		<string>group.app.rekuro.OneEighty</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Moves the entire app off the `com.danielbutler` reverse-DNS classifier and onto **`app.rekuro`** across every functional surface.

## What changed
- **Bundle identifiers** — main app `app.rekuro.OneEighty`, plus `.watchkitapp`, `.Widget`, and all Tests/UITests targets.
- **Watch companion pairing** — `WKCompanionAppBundleIdentifier` = `app.rekuro.OneEighty` (matches the phone app id), watch app = `app.rekuro.OneEighty.watchkitapp`.
- **App Group** — `group.app.rekuro.OneEighty` across both `.entitlements` files and every `UserDefaults(suiteName:)` / `containerURL(...)` call site.
- **Logger subsystems, dispatch-queue labels, Darwin notification names** in the Swift sources.
- **AGENTS.md** Bundle ID reference.

## Verification
- `xcodebuild build` for the iPhone 17 Pro simulator **succeeds**, including embedded-binary entitlement validation for the watch app and widget extension (this is what fails if the App Group / companion ids are inconsistent).
- Case-insensitive `danielbutler` sweep returns **zero** hits outside `docs/`.

## Deliberately not changed
- Historical plan/spec files under `docs/` (dated records; several even reference the older `MetronomeApp` name).

## Follow-up outside the repo
- App Store Connect / provisioning: new App IDs + an App Group capability registered for `group.app.rekuro.OneEighty` are needed before a device/TestFlight build.
- Existing installs get a fresh (empty) App Group container under the new suite — expected for an id change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UFexU6GSQyK6g1bzSWV1bb