### PR TITLE
feat: add Sextant Run awareness card to the main screen

### DIFF
--- a/OneEighty/ContentView.swift
+++ b/OneEighty/ContentView.swift
@@ -18,6 +18,10 @@ struct ContentView: View {
 
     var body: some View {
         VStack(spacing: 40) {
+            SextantCard()
+                .padding(.horizontal, 40)
+                .padding(.top, 8)
+
             Spacer()
 
             // BPM Display

--- a/OneEighty/SextantCard.swift
+++ b/OneEighty/SextantCard.swift
@@ -1,0 +1,87 @@
+//
+//  SextantCard.swift
+//  OneEighty
+//
+//  A quiet, persistent awareness card pointing to Sextant Run (sextant.run),
+//  the run-analysis companion. Cross-promo: people using a running-cadence
+//  metronome are structured runners, which is Sextant's beachhead audience.
+//
+
+import SwiftUI
+import os
+
+private let logger = Logger(subsystem: "app.rekuro.OneEighty", category: "SextantCard")
+
+/// Copy and destination for the Sextant cross-promo card. Kept as constants so
+/// the UTM attribution tags and the lede cannot silently drift out from under
+/// the analytics or the brand voice.
+enum SextantPromo {
+    static let title = "Sextant: Run Analysis"
+    static let lede = "ChatGPT for your runs, without the slop."
+
+    /// An https universal link: it opens the Sextant app directly once deep
+    /// links are live, and otherwise falls back to the web with the UTM params
+    /// intact for PostHog attribution.
+    static let url = URL(string:
+        "https://sextant.run/?utm_source=oneeighty&utm_medium=cross-promo&utm_campaign=home-card"
+    )!
+}
+
+/// A low-key, always-present card at the top of the main screen. Its job is
+/// awareness, not conversion: it should read like a sister-app shelf, not a
+/// banner. Tapping opens Sextant.
+struct SextantCard: View {
+    @Environment(\.openURL) private var openURL
+
+    var body: some View {
+        Button {
+            logger.info("Sextant card tapped, opening \(SextantPromo.url.absoluteString, privacy: .public)")
+            openURL(SextantPromo.url)
+        } label: {
+            HStack(spacing: 12) {
+                // Typographic mark, deliberately not a nautical/sextant icon.
+                Text("\u{25C7}")
+                    .font(.headline)
+                    .foregroundStyle(.secondary)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(SextantPromo.title)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.primary)
+                    Text(SextantPromo.lede)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer(minLength: 8)
+
+                Image(systemName: "arrow.up.right")
+                    .font(.footnote.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(.thinMaterial)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .stroke(.quaternary, lineWidth: 1)
+            )
+            .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .ignore)
+        .accessibilityIdentifier("sextantCard")
+        .accessibilityLabel("\(SextantPromo.title). \(SextantPromo.lede)")
+        .accessibilityHint("Opens sextant.run")
+        .accessibilityAddTraits(.isLink)
+    }
+}
+
+#Preview {
+    SextantCard()
+        .padding()
+}

--- a/OneEightyTests/SextantPromoTests.swift
+++ b/OneEightyTests/SextantPromoTests.swift
@@ -1,0 +1,26 @@
+//  SextantPromoTests.swift
+import XCTest
+@testable import OneEighty
+
+final class SextantPromoTests: XCTestCase {
+    func testURLCarriesPostHogUTMTags() {
+        let comps = URLComponents(url: SextantPromo.url, resolvingAgainstBaseURL: false)!
+        let items = Dictionary(
+            (comps.queryItems ?? []).map { ($0.name, $0.value) },
+            uniquingKeysWith: { first, _ in first }
+        )
+
+        XCTAssertEqual(comps.scheme, "https", "https keeps it universal-link compatible")
+        XCTAssertEqual(comps.host, "sextant.run")
+        XCTAssertEqual(items["utm_source"], "oneeighty")
+        XCTAssertEqual(items["utm_medium"], "cross-promo")
+        XCTAssertEqual(items["utm_campaign"], "home-card")
+    }
+
+    func testCopyIsPresentAndHasNoEmDash() {
+        XCTAssertFalse(SextantPromo.title.isEmpty)
+        XCTAssertFalse(SextantPromo.lede.isEmpty)
+        XCTAssertFalse(SextantPromo.lede.contains("\u{2014}"), "No em dashes in user-facing copy")
+        XCTAssertFalse(SextantPromo.title.contains("\u{2014}"), "No em dashes in user-facing copy")
+    }
+}


### PR DESCRIPTION
Adds a quiet, persistent cross-promo card at the top of the metronome screen pointing runners to **Sextant** ([sextant.run](https://sextant.run)), the run-analysis companion. People using a running-cadence metronome are Sextant's beachhead audience, so the placement itself is the targeting. Its job is awareness, not conversion, so it reads like a sister-app shelf rather than a banner.

## What's in it
- **`SextantCard`** — a low-key `.thinMaterial` card: `◇` mark, title, lede, and an `↗` external-link cue. The whole card is one tap target that opens Sextant via `openURL`, and logs the tap for observability.
- **`SextantPromo`** — copy + destination held as constants so the UTM tags and lede can't silently drift.
  - Title: **Sextant: Run Analysis**
  - Lede: **ChatGPT for your runs, without the slop.**
  - Link: `https://sextant.run/?utm_source=oneeighty&utm_medium=cross-promo&utm_campaign=home-card`
- **`SextantPromoTests`** — guards the UTM taxonomy and the copy (including a no-em-dash check).

## Why https (not a custom scheme)
An https link doubles as a universal link: it opens the Sextant app directly once `sextant.run`'s `apple-app-site-association` is live, and otherwise falls back to the web with the UTM params intact for PostHog attribution. A `sextant://` scheme would do neither.

## Verification
- Full `OneEightyTests` target passes.
- Card renders on the iPhone 17 Pro simulator above the BPM display without crowding the controls (screenshot in the linked session).

## Follow-ups (non-blocking, on the Sextant side)
- Confirm PostHog is capturing UTMs on `sextant.run` pageviews (default behavior).
- Once the `apple-app-site-association` is published, the card starts opening the Sextant app directly, no change needed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UFexU6GSQyK6g1bzSWV1bb